### PR TITLE
Fix for issue 149

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -849,8 +849,11 @@
             this.gotoDate(this._d);
 
             if (this._o.field) {
+                var old_value = this._o.field.value;
                 this._o.field.value = this.toString();
-                fireEvent(this._o.field, 'change', { firedBy: this });
+                if(this._o.field.value != old_value) {
+                    fireEvent(this._o.field, 'change', { firedBy: this });
+                }
             }
             if (!preventOnSelect && typeof this._o.onSelect === 'function') {
                 this._o.onSelect.call(this, this.getDate());


### PR DESCRIPTION
Edited setDate to resolve issue #149 where Pikaday unintentionally fires a 'change' event on page load, if the input form field associated with the Pikaday component contains a pre-filled value set from prior user input. The fix at lines 852-854 instead have the library temporarily cache the old value before setting the new value, then the old and new are compared before fireEvent() is called to trigger the 'change' event. The library will now only fire the 'change' event if the value has changed.

This has been successfully tested to resolve issue 149. Please feel free to accept the PR or adjust as desired.